### PR TITLE
Added local-branch deployment command to rebuild docs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,8 +11,13 @@ test:
     - docs/examples/collect.py --testing .
 
 deployment:
-  production:
-    branch: "migurski/tickle-docs-rebuild"
+  prerelease:
+    branch: "master"
+    commands:
+      - pip install 'Circle-Tickler == 1.0.1'
+      - tickle-circle mapzen mapzen-docs-generator tilezen-buildbot/tiles-prerelease-docs $CIRCLE_TOKEN
+  release:
+    tag: /.+/
     commands:
       - pip install 'Circle-Tickler == 1.0.1'
       - tickle-circle mapzen mapzen-docs-generator master $CIRCLE_TOKEN

--- a/circle.yml
+++ b/circle.yml
@@ -9,3 +9,10 @@ dependencies:
 test:
   override:
     - docs/examples/collect.py --testing .
+
+deployment:
+  production:
+    branch: "migurski/tickle-docs-rebuild"
+    commands:
+      - pip install 'Circle-Tickler == 1.0.1'
+      - tickle-circle mapzen mapzen-docs-generator master $CIRCLE_TOKEN


### PR DESCRIPTION
I am setting up some proactive connections from upstream documentation repos to the central Mapzen repository. This change will cause CircleCI to trigger rebuilds on that repository, after [merge of PR #233](https://github.com/mapzen/mapzen-docs-generator/pull/223).

- [x] Wait for tests to pass to verify that this works for this branch.
- [x] Reconfigure to run regardless of branch, or select a branch or release.