### PR TITLE
Add docs about tile size variants

### DIFF
--- a/docs/use-service.md
+++ b/docs/use-service.md
@@ -53,7 +53,7 @@ Note: GeoTIFF format tiles are 512x512 sized so request the parent tile’s coor
 ```
 https://tile.mapzen.com/mapzen/terrain/v1/skadi/{N|S}{y}/{N|S}{y}{E|W}{x}.hgt.gz?api_key={your_mapzen_api_key}
 ```
-  
+
 Note: Skadi files are split into 1° by 1° grids. File names refer to the latitude and longitude of the lower left corner of the tile - e.g. N37W105 has its lower left corner at 37 degrees north latitude and 105 degrees west longitude. For example:  N37W105: `https://tile.mapzen.com/mapzen/terrain/v1/skadi/N37/N37W105.hgt.gz?api_key={your_mapzen_api_key}`.
 
 #### Additional Amazon S3 Endpoints

--- a/docs/use-service.md
+++ b/docs/use-service.md
@@ -34,7 +34,7 @@ http://tile.mapzen.com/mapzen/terrain/v1/normal/11/330/790.png?api_key=your_mapz
 https://tile.mapzen.com/mapzen/terrain/v1/terrarium/{z}/{x}/{y}.png?api_key={your_mapzen_api_key}
 ```
 
-Supported tile size variants:
+Supported optional tile size variants:
 
   `https://tile.mapzen.com/mapzen/terrain/v1/{256,512,260,516}/terrarium/{z}/{x}/{y}.png`
 
@@ -46,7 +46,7 @@ The 260 and 516 variants contain 2 pixels of buffering on each edge.
 https://tile.mapzen.com/mapzen/terrain/v1/normal/{z}/{x}/{y}.png?api_key={your_mapzen_api_key}
 ```
 
-Supported tile size variants:
+Supported optional tile size variants:
 
   `https://tile.mapzen.com/mapzen/terrain/v1/{256,512}/normal/{z}/{x}/{y}.png`
 

--- a/docs/use-service.md
+++ b/docs/use-service.md
@@ -34,11 +34,21 @@ http://tile.mapzen.com/mapzen/terrain/v1/normal/11/330/790.png?api_key=your_mapz
 https://tile.mapzen.com/mapzen/terrain/v1/terrarium/{z}/{x}/{y}.png?api_key={your_mapzen_api_key}
 ```
 
+Supported tile size variants:
+
+  `https://tile.mapzen.com/mapzen/terrain/v1/{256,512,260,516}/terrarium/{z}/{x}/{y}.png`
+
+The 260 and 516 variants contain 2 pixels of buffering on each edge.
+
 ##### Normal
 
 ```
 https://tile.mapzen.com/mapzen/terrain/v1/normal/{z}/{x}/{y}.png?api_key={your_mapzen_api_key}
 ```
+
+Supported tile size variants:
+
+  `https://tile.mapzen.com/mapzen/terrain/v1/{256,512}/normal/{z}/{x}/{y}.png`
 
 ##### GeoTIFF
 


### PR DESCRIPTION
This should only get merged once the buffered terrain service is in production, and we are ready to go public with it.