### PR TITLE
[docs] better 512 px tile size documenation

### DIFF
--- a/docs/use-service.md
+++ b/docs/use-service.md
@@ -101,7 +101,6 @@ The maximum `{z}` value for 256 pixel tiles is zoom **15**. Requesting `{z}` coo
 **Default:**
 
 Including tile size in the path is not required. When not specified the default size of `256` is returned, and Tangram's default `tile_size` of 256 is used.
-.
 
 ```
 https://tile.mapzen.com/mapzen/terrain/v1/{format}/{z}/{x}/{y}.{extension}?api_key=your-mapzen-api-key


### PR DESCRIPTION
Including specifying 512 and zoom 14 max to fix #156.

Vector tile changes are over in https://github.com/tilezen/vector-datasource/pull/1399.

Like that other PR: This is off the `v1.0.0-docs11` branch that happens for docs to be the same as master. This PR should be merged to master before the v2 PR, and then we can just tag master as 
`v1.0.0-docs12` and releasing as latest will trigger Mapzen docs update.